### PR TITLE
Update examples to reflect changes to adafruit_lsm6ds

### DIFF
--- a/examples/lis3mdl_lsm6ds_test.py
+++ b/examples/lis3mdl_lsm6ds_test.py
@@ -1,6 +1,6 @@
 import time
 import board
-from adafruit_lsm6ds.lsm6Dsox import LSM6DSOX as LSM6DS
+from adafruit_lsm6ds.lsm6dsox import LSM6DSOX as LSM6DS
 
 # To use LSM6DS33, comment out the LSM6DSOX import line
 # and uncomment the next line

--- a/examples/lis3mdl_lsm6ds_test.py
+++ b/examples/lis3mdl_lsm6ds_test.py
@@ -1,14 +1,14 @@
 import time
 import board
-from adafruit_lsm6ds.LSM6DSOX import LSM6DSOX as LSM6DS
+from adafruit_lsm6ds.lsm6Dsox import LSM6DSOX as LSM6DS
 
 # To use LSM6DS33, comment out the LSM6DSOX import line
 # and uncomment the next line
-# from adafruit_lsm6ds.LSM6DS33 import LSM6DS33 as LSM6DS
+# from adafruit_lsm6ds.lsm6ds33 import LSM6DS33 as LSM6DS
 
 # To use ISM330DHCX, comment out the LSM6DSOX import line
 # and uncomment the next line
-# from adafruit_lsm6ds.ISM330DHCX import ISM330DHCX as LSM6DS
+# from adafruit_lsm6ds.lsm330dhcx import ISM330DHCX as LSM6DS
 
 from adafruit_lis3mdl import LIS3MDL
 

--- a/examples/lis3mdl_lsm6ds_test.py
+++ b/examples/lis3mdl_lsm6ds_test.py
@@ -1,14 +1,14 @@
 import time
 import board
-from adafruit_lsm6ds import LSM6DSOX as LSM6DS
+from adafruit_lsm6ds.LSM6DSOX import LSM6DSOX as LSM6DS
 
 # To use LSM6DS33, comment out the LSM6DSOX import line
 # and uncomment the next line
-# from adafruit_lsm6ds import LSM6DS33 as LSM6DS
+# from adafruit_lsm6ds.LSM6DS33 import LSM6DS33 as LSM6DS
 
 # To use ISM330DHCX, comment out the LSM6DSOX import line
 # and uncomment the next line
-# from adafruit_lsm6ds import ISM330DHCX as LSM6DS
+# from adafruit_lsm6ds.ISM330DHCX import ISM330DHCX as LSM6DS
 
 from adafruit_lis3mdl import LIS3MDL
 


### PR DESCRIPTION
`adafruit_lsm6ds` is a module now, these imports must change to reflect that