### PR TITLE
use LSM6DS3TRC because that's what the breakout has

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -33,8 +33,8 @@ LSM6DS Test
 
 Test the LSM6DS device
 
-.. literalinclude:: ../examples/lis3mdl_lsm6ds_test.py
-    :caption: examples/lis3mdl_lsm6ds_test.py
+.. literalinclude:: ../examples/lis3mdl_lsm6ds3trc_test.py
+    :caption: examples/lis3mdl_lsm6ds3trc_test.py
     :linenos:
 
 Range Test

--- a/examples/lis3mdl_lsm6ds3trc_test.py
+++ b/examples/lis3mdl_lsm6ds3trc_test.py
@@ -14,7 +14,7 @@ from adafruit_lsm6ds.lsm6dsox import LSM6DSOX as LSM6DS
 # from adafruit_lsm6ds.lsm330dhcx import ISM330DHCX as LSM6DS
 # To use LSM6DS3TR-C, comment out the LSM6DSOX import line
 # and uncomment the next line
-# from adafruit_lsm6ds.lsm6ds3 import LSM6DS3 as LSM6DS
+# from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC as LSM6DS
 from adafruit_lis3mdl import LIS3MDL
 
 i2c = board.I2C()  # uses board.SCL and board.SDA


### PR DESCRIPTION
Thanks `@florigon` for noticing this.

Changed the import to use the chip variant that the breakout has, and also rename to match.

This example works either way but if the pedometer function were added to the example, it would not work.